### PR TITLE
feat: add support windows os

### DIFF
--- a/daily_windows.py
+++ b/daily_windows.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import sys
+import pyexcel_ods
+from datetime import datetime
+import os
+import pyperclip
+from utils import format_work, capitalize_first, format_work_hipe, verify_date
+
+
+def make_daily_task(*args):
+    try:
+        home_dir = os.path.expanduser("~")
+        desktop_path = os.path.join(home_dir, "OneDrive", "Desktop")
+        calc_path = os.path.join(desktop_path, "reports.ods")
+
+        if len(args) == 0:
+            raise Exception("ERROR: Missing tasks for tomorrow.")
+
+        # Read the .ods file
+        data = pyexcel_ods.get_data(calc_path)
+        sheet = data[list(data.keys())[0]]  # Get the first sheet
+
+        todays_work = []
+        today = datetime.today().date()
+
+        for row in sheet:
+            if len(row) < 3:
+                continue
+
+            date = row[0]
+
+            if date is None:
+                continue
+
+            date = verify_date(date)
+
+            if date != today:
+                continue
+
+            task = row[1]
+            percentage = int(row[2])
+
+            todays_work.append((task, percentage))
+
+        today_header = "■Today's work"
+        formatted_today = "\n".join([f"{format_work(work)}" for work in todays_work])
+
+        tomorrow_header = "■Tomorrow's work schedule"
+        formatted_tomorrow = "\n".join([f"- {capitalize_first(task)}" for task in args])
+
+        formatted_problems = "■Problem\n- None in particular"
+
+        lrt_daily = f"{today_header}\n{formatted_today}\n{tomorrow_header}\n{formatted_tomorrow}\n{formatted_problems}"
+        hipe_daily = "\n".join(
+            [f"{format_work_hipe(work[0], work[1])}" for work in todays_work]
+        )
+
+        pyperclip.copy(lrt_daily)
+
+        print(lrt_daily)
+        print("\nLRT daily report copied to clipboard! ...For HiPE daily report:\n")
+        print(hipe_daily)
+    except Exception as e:
+        print(e)
+
+
+if __name__ == "__main__":
+    make_daily_task(*sys.argv[1:])

--- a/monthly_windows.py
+++ b/monthly_windows.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+from collections import OrderedDict
+import sys
+import pyexcel_ods
+import datetime
+import calendar
+import os
+import pyperclip
+from utils import verify_date, get_closer_year, format_for_spreadsheet
+from pprint import pprint
+from WorkDateTime import WorkDateTime
+
+
+def make_monthly_report(*args):
+    """
+    get list of unique tasks
+        - for every row in reports:
+            - save each task, in order. List of Dicts.
+                [ {date, task, weight}, ... ]
+            - save each unique task & percent completion, in order. ordered Dicts.
+                { task: highest_percentage, ... }
+            - save weights & hours per day, in order. ordered Dict.
+                { workday: { total_weight, total_mins=480 }, ... }
+
+    get the exact days you went to work (off days removed)
+        - for each task in tasks:
+            - get total mins per task per day (using weight / total_weight * total_mins).
+            - add it to all_tasks, as mins, below:
+            all_tasks = [ { date: 1234, task: "asdf", weight: 1, mins: 555 }, ... ]
+            - sum hours per unique task.
+            unique_tasks = {
+                    task: {
+                    completion: 100%,
+                    total_mins: 5555, # sum of mins above
+                    },
+                    ...
+                }
+
+    distribute each task along the total hours of the month.
+
+    paste into a CSV to fit rows in? tabs and enters
+    """
+    try:
+        home_dir = os.path.expanduser("~")
+        desktop_path = os.path.join(home_dir, "OneDrive" , "Desktop")
+        calc_path = os.path.join(desktop_path, "reports.ods")
+
+        if len(args) == 0 or int(args[0]) not in range(1, 13):
+            raise Exception("ERROR: Invalid month number.")
+
+        month_number = int(args[0])
+        year = get_closer_year(month_number)
+        month_start = datetime.datetime(year, month_number, 1)  # Set day to 1 for consistency
+        days_in_month = calendar.monthrange(year, month_number)[1]
+        month_end = month_start + datetime.timedelta(days=days_in_month - 1)
+        month_start = month_start.date()
+        month_end = month_end.date()
+
+        all_tasks = []
+        unique_tasks = OrderedDict()
+        unique_dates = OrderedDict()
+
+        # Read the .ods file
+        data = pyexcel_ods.get_data(calc_path)
+        sheet = data[list(data.keys())[0]]  # Get the first sheet
+
+        # Process input
+        for row in sheet:
+            if len(row) < 4:
+                continue
+
+            date = row[0]
+
+            if date is None:
+                continue
+
+            date = verify_date(date)
+
+            # Only use the indicated month's dates
+            if not month_start <= date <= month_end:
+                continue
+
+            task = row[1]
+            percentage = row[2]
+            weight = row[3]
+
+            all_tasks.append(
+                {
+                    "date": date,
+                    "task": task,
+                    "weight": weight,
+                }
+            )
+
+            if task not in unique_tasks:
+                unique_tasks[task] = {
+                    "completion": percentage,
+                    "total_mins": 0,
+                    "dates": {},
+                    "begin": None,
+                    "end": None,
+                }
+            else:
+                if unique_tasks[task]["completion"] < percentage:
+                    unique_tasks[task]["completion"] = percentage
+
+            if date not in unique_dates:
+                unique_dates[date] = {
+                    "total_weight": weight,
+                    "total_mins": 480,
+                }
+            else:
+                unique_dates[date]["total_weight"] += weight
+
+        # Get total minutes per unique task
+        for task_data in all_tasks:
+            date = task_data["date"]
+            task = task_data["task"]
+            weight = task_data["weight"]
+
+            total_mins_for_day = unique_dates[date]["total_mins"]
+            task_mins = round(
+                (weight / unique_dates[date]["total_weight"]) * total_mins_for_day
+            )
+            unique_tasks[task]["total_mins"] += task_mins
+
+        def convert_date_to_workdt(list, date, time=None):
+            if time:
+                return WorkDateTime(
+                    list, date.year, date.month, date.day, time.hour, time.minute
+                )
+            return WorkDateTime(list, date.year, date.month, date.day)
+
+        timeframes = {}
+
+        date_index = 0
+        list_of_date_keys = list(unique_dates.keys())
+
+        start_date = list_of_date_keys[date_index]
+        current_workdt = convert_date_to_workdt(list_of_date_keys, start_date)
+        for task in unique_tasks:
+            if task not in timeframes:
+                total_mins = unique_tasks[task]["total_mins"]
+                next_workdt = current_workdt + datetime.timedelta(minutes=total_mins)
+                total_workdays = total_mins / 60 / 9
+                timeframes[task] = (
+                    current_workdt.datetime,
+                    next_workdt.datetime,
+                    total_workdays,
+                )
+
+                current_workdt = current_workdt + datetime.timedelta(minutes=total_mins)
+
+        for task in unique_tasks:
+            unique_tasks[task]["begin"] = timeframes[task][0]
+            unique_tasks[task]["end"] = timeframes[task][1]
+            unique_tasks[task]["duration"] = timeframes[task][2]
+
+        monthly_string = format_for_spreadsheet(unique_tasks)
+        pyperclip.copy(monthly_string)
+
+        month_name = calendar.month_name[month_number]
+        print(f"Monthly report for {month_name} {year} copied to clipboard!")
+
+    except Exception as e:
+        print(e)
+
+
+if __name__ == "__main__":
+    make_monthly_report(*sys.argv[1:])

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 from pendulum import DateTime as pendulumdatetime
+import platform
 
 
 def format_work(data):
@@ -46,7 +47,13 @@ def get_week_range_string(week_dates):
 def verify_date(date):
     if isinstance(date, str):
         print(f"string date, parsing... {date}")
-        date = datetime.strptime(date, "%b %d, %Y").date()
+        if platform.system() == "Windows":
+            date = datetime.datetime.strptime(date, "%m/%d/%Y").date()
+        elif platform.system() == "Darwin":
+            date = datetime.strptime(date, "%m/%d/%y").date()
+        else:
+            raise NotImplementedError("Unsupported operating system")
+
 
     if isinstance(date, pendulumdatetime):
         # print(f"pendulum date, parsing... {date}")

--- a/utils.py
+++ b/utils.py
@@ -27,8 +27,15 @@ def capitalize_first(s):
 
 
 def get_week_range_string(week_dates):
-    start = week_dates[min]
-    end = week_dates[max]
+    if platform.system() == "Windows":
+        start = week_dates["min"]
+        end = week_dates["max"]
+    elif platform.system() == "Darwin":
+        start = week_dates[min]
+        end = week_dates[max]
+    else:
+        raise NotImplementedError("Unsupported operating system")
+    
     if start.month != end.month:
         formatted_date_range = (
             f"{start.strftime('%B %d')} - {end.strftime('%B %d, %Y')}"

--- a/weekly_windows.py
+++ b/weekly_windows.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+from collections import OrderedDict
+import sys
+import pyexcel_ods
+import datetime
+import os
+import pyperclip
+from utils import get_week_range_string, format_work_hipe, verify_date
+
+
+def make_weekly_task(start_date=None, end_date=None):
+    try:
+        home_dir = os.path.expanduser("~")
+        desktop_path = os.path.join(home_dir, "OneDrive", "Desktop")
+        calc_path = os.path.join(desktop_path, "reports.ods")
+
+        # Read the .ods file
+        data = pyexcel_ods.get_data(calc_path)
+        sheet = data[list(data.keys())[0]]  # Get the first sheet
+
+        today = datetime.datetime.now().date()
+
+        if start_date is None or end_date is None:
+            start_of_this_week = today + datetime.timedelta(days=-today.weekday())
+            end_of_this_week = start_of_this_week + datetime.timedelta(days=4)
+        else:
+            start_of_this_week = datetime.datetime.strptime(start_date, "%Y-%m-%d").date()
+            end_of_this_week = datetime.datetime.strptime(end_date, "%Y-%m-%d").date()
+
+        # Check if today is within the specified date range
+        if not (start_of_this_week <= today <= end_of_this_week):
+            print(f"Today's date {today} is not within the specified date range {start_of_this_week} to {end_of_this_week}.")
+            return
+
+        week_dates = [start_of_this_week + datetime.timedelta(days=i) for i in range((end_of_this_week - start_of_this_week).days + 1)]
+
+        weekly_tasks = {}
+        week_range = {"start_date": datetime.date.max, "end_date": datetime.date.min}
+
+        for row in sheet:
+            if len(row) < 3:
+                continue
+
+            date = row[0]
+
+            if date is None:
+                continue
+
+            date = verify_date(date)
+
+            if not any(date == weekdate for weekdate in week_dates):
+                continue
+
+            if week_range["start_date"] > date:
+                week_range["start_date"] = date
+            if week_range["end_date"] < date:
+                week_range["end_date"] = date
+
+            task = row[1]
+            percentage = int(row[2])
+
+            if task not in weekly_tasks:
+                weekly_tasks[task] = percentage
+            else:
+                weekly_tasks[task] = max(weekly_tasks[task], percentage)
+
+        week_range_str = get_week_range_string(week_range)
+        title = "LRTechs"
+        hipe_weekly = "\n".join(
+            [f"- {format_work_hipe(task, perc, ':')}" for task, perc in weekly_tasks.items()]
+        )
+        weekly_string = f"{week_range_str}\n{title}\n{hipe_weekly}"
+
+        pyperclip.copy(weekly_string)
+        print(weekly_string)
+        print("\nWeekly report copied to clipboard!")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3:
+        make_weekly_task(sys.argv[1], sys.argv[2])
+    else:
+        make_weekly_task()

--- a/weekly_windows.py
+++ b/weekly_windows.py
@@ -36,7 +36,7 @@ def make_weekly_task(start_date=None, end_date=None):
         week_dates = [start_of_this_week + datetime.timedelta(days=i) for i in range((end_of_this_week - start_of_this_week).days + 1)]
 
         weekly_tasks = {}
-        week_range = {"start_date": datetime.date.max, "end_date": datetime.date.min}
+        week_range = {"min": datetime.date.max, "max": datetime.date.min}
 
         for row in sheet:
             if len(row) < 3:
@@ -52,10 +52,10 @@ def make_weekly_task(start_date=None, end_date=None):
             if not any(date == weekdate for weekdate in week_dates):
                 continue
 
-            if week_range["start_date"] > date:
-                week_range["start_date"] = date
-            if week_range["end_date"] < date:
-                week_range["end_date"] = date
+            if week_range["min"] > date:
+                week_range["min"] = date
+            if week_range["max"] < date:
+                week_range["max"] = date
 
             task = row[1]
             percentage = int(row[2])


### PR DESCRIPTION
This PR introduces support for the Windows OS. For Windows users, instead of using numbers, LibreOffice will be utilized.

Instructions for Setting Up:
Place the reports.ods file in the Desktop directory so that the script can locate it.

Currently, the shell scripts do not automatically set up the scripts for Windows. Therefore, you will need to manually navigate to the cloned repository directory and run the script using Python.

You can download LibreOffice from the official website here: [LibreOffice Download](https://www.libreoffice.org/download/download-libreoffice/).